### PR TITLE
Fix: Resolve 'reinterpret_cast' issue by respecting const correctness…

### DIFF
--- a/sem 4/DSA/F24.cpp
+++ b/sem 4/DSA/F24.cpp
@@ -82,24 +82,24 @@ void deleteEmployee() {
         indexFile.close();
         indexFile.open("index.dat", ios::out | ios::binary | ios::trunc);
         for (const auto& idx : indices) {
-            indexFile.write(reinterpret_cast<char*>(&idx), sizeof(idx));
+            indexFile.write(reinterpret_cast<const char*>(&idx), sizeof(idx)); // Change here
         }
-        
+
         // Create a new data file excluding the deleted employee
         ofstream tempDataFile("temp_employees.dat", ios::binary);
         Employee emp;
         long position;
-        
+
         while (dataFile.read(reinterpret_cast<char*>(&emp), sizeof(emp))) {
             position = dataFile.tellg();
             if (position != indexEntry.position) {
-                tempDataFile.write(reinterpret_cast<char*>(&emp), sizeof(emp));
+                tempDataFile.write(reinterpret_cast<const char*>(&emp), sizeof(emp)); // Change here
             }
         }
-        
+
         dataFile.close();
         tempDataFile.close();
-        
+
         // Replace the original file with the temp file
         remove("employees.dat");
         rename("temp_employees.dat", "employees.dat");
@@ -111,6 +111,7 @@ void deleteEmployee() {
 
     indexFile.close();
 }
+
 
 void displayEmployee() {
     int empID;


### PR DESCRIPTION
… when writing to files

In the deleteEmployee() function, fixed the error caused by 'reinterpret_cast' from 'const Index*' to 'char*' which discarded the 'const' qualifier. The issue was resolved by casting with 'reinterpret_cast<const char*>(&idx)' and 'reinterpret_cast<const char*>(&emp)' to maintain const correctness when writing to the binary files.

This change ensures that const-qualified data is not inadvertently modified and preserves the integrity of the original employee and index records during file operations.